### PR TITLE
 Add Maybe for Part

### DIFF
--- a/src/Url.elm
+++ b/src/Url.elm
@@ -6,11 +6,16 @@ module Url
         , root
         , append
         , s
+        , maybeS
         , int
+        , maybeInt
         , string
+        , maybeString
         , bool
+        , maybeBool
         , hash
         , custom
+        , maybeCustom
         , appendParam
         , (</>)
         , (<#>)
@@ -43,7 +48,7 @@ with records to give the parameters names and therefore reducing errors.
 
 # Builders
 
-@docs root, append, s, int, string, bool, hash, custom, appendParam, (</>), (<#>), (<?>)
+@docs root, append, s, maybeS, int, maybeInt, string, maybeString, bool, maybeBool, hash, custom, maybeCustom, appendParam, (</>), (<#>), (<?>)
 
 
 # Presenting
@@ -66,7 +71,7 @@ type Url a
 {-| A parameterized part (segment or query value) of a URL.
 -}
 type Part a
-    = Part { toString : a -> String, skipUriEncode : Bool }
+    = Part { toString : a -> Maybe String, skipUriEncode : Bool }
 
 
 {-| URL-encode the given String if the Bool is True; otherwise, do nothing to
@@ -86,22 +91,28 @@ encodeUriPart encode =
 
 {-| Extract the given Part from the given record.
 
-    extractPart { a = "b c" } (Part { toString = .a, skipUriEncode = False})
-        == "b%20c"
-    extractPart { a = "b c" } (Part { toString = .a, skipUriEncode = True})
-        == "b c"
+    extractPart { a = "b c" } (Part { toString = .a >> Just, skipUriEncode = False})
+        == Just "b%20c"
+    extractPart { a = "b c" } (Part { toString = .a >> Just, skipUriEncode = True})
+        == Just "b c"
+    extractPart
+        { a = Just "b c" }
+        (Part { toString = .a, skipUriEncode = False})
+        == Just "b%20c"
+    extractPart
+        { a = Nothing }
+        (Part { toString = .a, skipUriEncode = False})
+        == Nothing
 
 -}
-extractPart : a -> Part a -> String
+extractPart : a -> Part a -> Maybe String
 extractPart p (Part { toString, skipUriEncode }) =
-    p
-        |> encodeUriPart skipUriEncode
-        << toString
+      Maybe.map (encodeUriPart skipUriEncode) (toString p)
 
 
 {-| Extract from a record and format a Part for a path.
 -}
-pathPartToString : a -> Part a -> String
+pathPartToString : a -> Part a -> Maybe String
 pathPartToString =
     extractPart
 
@@ -110,25 +121,33 @@ pathPartToString =
 
     queryPartToString
         ("a b", { c = "d e" } )
-        (Part { toString = .a, skipUriEncode = False})
-        == "a%20b=c%20d"
+        (Part { toString = .a >> Just, skipUriEncode = False})
+        == Just "a%20b=c%20d"
     queryPartToString
         ("a b", { c = "d e" } )
-        (Part { toString = .a, skipUriEncode = True})
-        == "a%20b=c d"
+        (Part { toString = .a >> Just, skipUriEncode = True})
+        == Just "a%20b=c d"
+    queryPartToString
+        ("a b", { c = Just "d e" } )
+        (Part { toString = .a, skipUriEncode = False})
+        == Just "a%20b=c%20d"
+    queryPartToString
+        ("a b", { c = Nothing } )
+        (Part { toString = .a, skipUriEncode = False})
+        == Nothing
 
 -}
-queryPartToString : a -> ( String, Part a ) -> String
+queryPartToString : a -> ( String, Part a ) -> Maybe String
 queryPartToString p ( name, part ) =
-    Http.encodeUri name ++ "=" ++ (extractPart p part)
+    Maybe.map ((++) (Http.encodeUri name ++ "=")) (extractPart p part)
 
 
 {-| Reads all of the Parts from the record and concatenates them with the
 supplied separator.
 -}
-readAndCombineParts : (a -> b -> String) -> a -> String -> List b -> String
+readAndCombineParts : (a -> b -> Maybe String) -> a -> String -> List b -> String
 readAndCombineParts mapper p separator =
-    String.join separator << List.map (mapper p)
+    String.join separator << List.filterMap (mapper p)
 
 
 {-| Give a string representation of the URL, given a value for the parameter.
@@ -165,6 +184,34 @@ append segment (Url ( segments, queries )) =
     Url ( segments ++ [ segment ], queries )
 
 
+{-| When some of the Part-constructing functions accepting a function with
+co-domain of Maybe b is supplied (such as maybeCustom and maybeInt), then the
+return value is an equivalent function sans Maybe.
+
+    fromMaybe maybeCustom == custom
+    fromMaybe maybeInt == int
+-}
+fromMaybe : ((a -> Maybe b) -> Part a) -> (a -> b) -> Part a
+fromMaybe f =
+    f << ((<<) Just)
+
+
+{-| Build a custom part with a Maybe value; it is omitted when the value is
+Nothing.
+
+    import String.Extra exposing (fromInt)
+
+    root
+        |> append (custom (.ids >> List.map fromInt >> String.join ";" >> Just))
+        |> Url.toString { ids = [1, 2, 3] }
+        == "/1%3B2%3B3"
+
+-}
+maybeCustom : (a -> Maybe String) -> Part a
+maybeCustom extract =
+    Part { toString = extract, skipUriEncode = False }
+
+
 {-| Build a custom part.
 
     import String.Extra exposing (fromInt)
@@ -176,8 +223,22 @@ append segment (Url ( segments, queries )) =
 
 -}
 custom : (a -> String) -> Part a
-custom extract =
-    Part { toString = extract, skipUriEncode = False }
+custom =
+    fromMaybe maybeCustom
+
+
+{-| Build a custom part without URL-encoding and with a Maybe value; it is
+omitted when the value is Nothing.
+
+    root
+        |> append (custom (.ids >> String.join ";" >> Just))
+        |> Url.toString { ids = ["1", "2 3", "4"] }
+        == "/1;2 3;4"
+
+-}
+maybeCustomRaw : (a -> Maybe String) -> Part a
+maybeCustomRaw extract =
+    Part { toString = extract, skipUriEncode = True }
 
 
 {-| Build a custom part without URL-encoding.
@@ -189,8 +250,23 @@ custom extract =
 
 -}
 customRaw : (a -> String) -> Part a
-customRaw extract =
-    Part { toString = extract, skipUriEncode = True }
+customRaw =
+    fromMaybe maybeCustomRaw
+
+
+{-| An unparameterized (static) part with a Maybe value; it is omitted when the
+value is Nothing.
+
+    root
+        |> append (maybeS (Just "users"))
+        |> append (maybeS Nothing)
+        |> append (maybeS (Just "1"))
+        |> Url.toString () == "/users/1"
+
+-}
+maybeS : Maybe String -> Part a
+maybeS =
+    maybeCustom << always
 
 
 {-| An unparameterized (static) part.
@@ -199,8 +275,26 @@ customRaw extract =
 
 -}
 s : String -> Part a
-s str =
-    custom (always str)
+s =
+    custom << always
+
+
+{-| A parameterized (variable) integer part with a Maybe value; it is omitted
+when the value is Nothing.
+
+    url =
+        root
+            |> append (s "users")
+            |> append (maybeInt .id)
+            |> append (s "images")
+
+    Url.toString { id = Just 42 } url == "/users/42/images"
+    Url.toString { id = Nothing } url == "/users/images"
+
+-}
+maybeInt : (a -> Maybe Int) -> Part a
+maybeInt extract =
+    maybeCustom (Maybe.map String.fromInt << extract)
 
 
 {-| A parameterized (variable) integer part.
@@ -213,8 +307,26 @@ s str =
 
 -}
 int : (a -> Int) -> Part a
-int extract =
-    custom (String.fromInt << extract)
+int =
+    fromMaybe maybeInt
+
+
+{-| A parameterized string part with a Maybe value; it is omitted when the value
+is Nothing.
+
+    url =
+        root
+            |> append (s "say")
+            |> append (maybeString .word)
+            |> append (s "world")
+
+    Url.toString { word = Just "Hello" } url == "/say/Hello/world"
+    Url.toString { word = Nothing } url == "/say/world"
+
+-}
+maybeString : (a -> Maybe String) -> Part a
+maybeString =
+    maybeCustom
 
 
 {-| A parameterized string part.
@@ -231,6 +343,29 @@ string =
     custom
 
 
+{-| A parameterized boolean part with a Maybe value; it is omitted when the
+value is Nothing.
+
+    url =
+        root
+            |> append (maybeBool .show)
+
+    Url.toString { show = Just True } url == "/true"
+    Url.toString { show = Nothing } url == "/"
+
+-}
+maybeBool : (a -> Maybe Bool) -> Part a
+maybeBool extract =
+    let
+        fromBool b =
+            if b then
+                "true"
+            else
+                "false"
+    in
+        maybeCustom (Maybe.map fromBool << extract)
+
+
 {-| A parameterized boolean part.
 
     root
@@ -240,15 +375,8 @@ string =
 
 -}
 bool : (a -> Bool) -> Part a
-bool extract =
-    let
-        fromBool b =
-            if b then
-                "true"
-            else
-                "false"
-    in
-        custom (fromBool << extract)
+bool =
+    fromMaybe maybeBool
 
 
 {-| A hash-only part.

--- a/tests/Test/Url.elm
+++ b/tests/Test/Url.elm
@@ -25,6 +25,21 @@ suite =
                 (Url.root |> Url.append (Url.s "part1") |> Url.append (Url.s "part2"))
                     |> Url.toString ()
                     |> Expect.equal "/part1/part2"
+        , test "Can append two Nothing static parts" <|
+            \_ ->
+                (Url.root |> Url.append (Url.maybeS Nothing) |> Url.append (Url.maybeS Nothing))
+                    |> Url.toString ()
+                    |> Expect.equal "/"
+        , test "Can append a Just and a Nothing static part" <|
+            \_ ->
+                (Url.root |> Url.append (Url.maybeS (Just "part1")) |> Url.append (Url.maybeS Nothing))
+                    |> Url.toString ()
+                    |> Expect.equal "/part1"
+        , test "Can append two Just static parts" <|
+            \_ ->
+                (Url.root |> Url.append (Url.maybeS (Just "part1")) |> Url.append (Url.maybeS (Just "part2")))
+                    |> Url.toString ()
+                    |> Expect.equal "/part1/part2"
         , test "Can append variable integer" <|
             \_ ->
                 (Url.root |> Url.append (Url.int .id))
@@ -50,15 +65,40 @@ suite =
                 (Url.root |> Url.append (Url.int .otherId) |> Url.append (Url.int .id))
                     |> Url.toString { id = 42, otherId = 24 }
                     |> Expect.equal "/24/42"
+        , test "Can append two Nothing integers" <|
+            \_ ->
+                (Url.root |> Url.append (Url.maybeInt .id) |> Url.append (Url.maybeInt .otherId))
+                    |> Url.toString { id = Nothing, otherId = Nothing }
+                    |> Expect.equal "/"
+        , test "Can append a Just and a Nothing integer" <|
+            \_ ->
+                (Url.root |> Url.append (Url.maybeInt .id) |> Url.append (Url.maybeInt .otherId))
+                    |> Url.toString { id = Just 42, otherId = Nothing }
+                    |> Expect.equal "/42"
+        , test "Can append two Just integers" <|
+            \_ ->
+                (Url.root |> Url.append (Url.maybeInt .id) |> Url.append (Url.maybeInt .otherId))
+                    |> Url.toString { id = Just 42, otherId = Just 24 }
+                    |> Expect.equal "/42/24"
         , test "Can append a string" <|
             \_ ->
                 (Url.root |> Url.append (Url.string .name))
                     |> Url.toString { name = "everything" }
                     |> Expect.equal "/everything"
+        , test "Can append a Just string" <|
+            \_ ->
+                (Url.root |> Url.append (Url.maybeString .name))
+                    |> Url.toString { name = Just "everything" }
+                    |> Expect.equal "/everything"
         , test "Can append a bool" <|
             \_ ->
                 (Url.root |> Url.append (Url.bool .show))
                     |> Url.toString { show = True }
+                    |> Expect.equal "/true"
+        , test "Can append a Just bool" <|
+            \_ ->
+                (Url.root |> Url.append (Url.maybeBool .show))
+                    |> Url.toString { show = Just True }
                     |> Expect.equal "/true"
         , test "Infix append works" <|
             \_ ->
@@ -78,6 +118,15 @@ suite =
                     (Url.root |> Url.append idsSegment)
                         |> Url.toString { ids = [ 1, 2, 3 ] }
                         |> Expect.equal ("/" ++ Http.encodeUri "1;2;3")
+        , test "Can use custom Maybe segment" <|
+            \_ ->
+                let
+                    idsSegment =
+                        Url.maybeCustom (.ids >> List.filterMap (Maybe.map String.Extra.fromInt) >> String.join ";" >> Just)
+                in
+                    (Url.root |> Url.append idsSegment)
+                        |> Url.toString { ids = [ Just 1, Nothing, Just 3 ] }
+                        |> Expect.equal ("/" ++ Http.encodeUri "1;3")
         , test "Can append parameter" <|
             \_ ->
                 (Url.root |> Url.append (Url.s "part") |> Url.appendParam "id" (Url.int .id))
@@ -88,6 +137,11 @@ suite =
                 (Url.root |> Url.append (Url.s "part") |> Url.appendParam "id" (Url.int .id) |> Url.appendParam "show" (Url.bool .show))
                     |> Url.toString { id = 42, show = True }
                     |> Expect.equal "/part?id=42&show=true"
+        , test "Can append a Nothing and a Just parameter" <|
+            \_ ->
+                (Url.root |> Url.append (Url.maybeS (Just "part")) |> Url.appendParam "id" (Url.maybeInt .id) |> Url.appendParam "show" (Url.maybeBool .show))
+                    |> Url.toString { id = Just 42, show = Nothing }
+                    |> Expect.equal "/part?id=42"
         , test "Can have static parts, variables, and parameters" <|
             \_ ->
                 (Url.root |> Url.append (Url.s "part") |> Url.append (Url.int .id) |> Url.appendParam "show" (Url.bool .show))


### PR DESCRIPTION
Closes #3

This adds support for optional parts through the `maybe*`-functions.

I’ve also refactored some parts and added `customRaw` and `maybeCustomRaw`, which have `skipUriEncode = True`; currently, `customRaw` is only used for `hash` (`customRaw (always "#")`) and neither of them is exposed.